### PR TITLE
Update mixer.py with instructions

### DIFF
--- a/plugins/mixer.py
+++ b/plugins/mixer.py
@@ -89,3 +89,4 @@ class Plugin(BasePlugin):
 
     
     
+


### PR DESCRIPTION
I have no proposed change (except for instructions) , but in light of recent updates to Ubuntu I and some differences in communities that have involved forkings (debian v. devuan and more), I think is is wise to provide users basic (very basic!) instructions (different based on what operating system they are using) - ubuntu vs. debian v. etc., etc., etc. For example, I have Ubuntu 14.04 LTS (64 bit) and am not getting rid of it anytime soon.  I would iike to see some simple steps for how I can get this mixer plugin into my electrum in a few steps, because post Dec. 17 update, more changes have come and one can no longer just drop it into some expected plugin folder.  Please develop up some (simple) instructions.  Thank you.
